### PR TITLE
remove unnecessary call to Math.abs

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -60,7 +60,7 @@ export default class JustATributeApp extends Component {
         let newIndex = (index + delta) % Images.length;
 
         if (newIndex < 0) {
-            newIndex = Images.length - Math.abs(newIndex);
+            newIndex = Images.length + newIndex;
         }
 
         this.setState({


### PR DESCRIPTION
`newIndex< 0 => Math.abs(newIndex)` is always `-newIndex`
ps : Thank you for the great tutorial 